### PR TITLE
Upgrade to .net core 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ docker run --rm -it \
 
 ## Developing peekaqueue
 
-Peekqueue is a .NET Core 2.2 application. You can download the .NET Core runtime and tools [here](http://dot.net).
+Peekqueue is a .NET Core 3.1 application. You can download the .NET Core runtime and tools [here](http://dot.net).

--- a/src/Peekaqueue/Dockerfile
+++ b/src/Peekaqueue/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk-alpine AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
 
 ARG BUILDCONFIG=RELEASE
 ARG VERSION=1.0.0
@@ -13,7 +13,7 @@ COPY ./ ./
 RUN dotnet publish -c $BUILDCONFIG -o out /p:Version=$VERSION
 
 # build runtime image
-FROM microsoft/dotnet:2.2-aspnetcore-runtime-alpine
+FROM mcr.microsoft.com/dotnet/core/runtime:3.1-alpine
 WORKDIR /app
 COPY --from=build /build/out ./
 

--- a/src/Peekaqueue/Peekaqueue.csproj
+++ b/src/Peekaqueue/Peekaqueue.csproj
@@ -1,23 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0"/>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2"/>
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1"/>
-    <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0"/>
-    <PackageReference Include="SerilogTimings" Version="2.2.0"/>
-    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.2"/>
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.1"/>
-    <PackageReference Include="AWSSDK.ECS" Version="3.3.101.8"/>
-    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.101.7"/>
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="6.0.1"/>
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+    <PackageReference Include="SerilogTimings" Version="2.2.0" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.3.3.2" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.1" />
+    <PackageReference Include="AWSSDK.ECS" Version="3.3.101.8" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="3.3.101.7" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1" />
     <PackageReference Include="prometheus-net" Version="2.1.3" />
     <PackageReference Include="Polly" Version="6.1.1" />
   </ItemGroup>

--- a/src/Peekaqueue/Program.cs
+++ b/src/Peekaqueue/Program.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using Amazon.CloudWatch;
 using Amazon.ECS;
@@ -9,7 +8,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
-using Serilog.Extensions.Logging;
 
 namespace Peekaqueue
 {

--- a/src/Peekaqueue/appsettings.json
+++ b/src/Peekaqueue/appsettings.json
@@ -23,9 +23,7 @@
       "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
-        "System": "Warning",
-        "Gateway.Api.Security.ApiKeyAuthenticationHandler": "Warning",
-        "Couchbase": "Warning"
+        "System": "Warning"
       }
     },
     "WriteTo": [


### PR DESCRIPTION
## Comments

Upgrade to 3.1 to be on the current LTS version

## Changes

- Upgrade to .net core 3.1 including Microsoft extension packages
- Updated Dockerfile to use official Microsoft registry
- Removed irrelevant logging overrides (Couchbase and something related to a library that is not publicly available)