### PR TITLE
Adding AWS services config override 

### DIFF
--- a/src/Peekaqueue/AwsServiceCollectionExtensions.cs
+++ b/src/Peekaqueue/AwsServiceCollectionExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using Amazon.Runtime;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Peekaqueue
+{
+    public static class AwsServiceCollectionExtensions
+    {
+        public static IServiceCollection AddAWSServiceWithOverride<T>(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            string overrideSectionName,
+            ServiceLifetime lifetime = ServiceLifetime.Singleton) where T : IAmazonService
+        {
+            if (services == null) throw new ArgumentException(nameof(services));
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+
+            return !string.IsNullOrWhiteSpace(overrideSectionName) && configuration.GetSection(overrideSectionName).Exists() ? 
+                services.AddAWSService<T>(configuration.GetAWSOptions(overrideSectionName), lifetime) : services.AddAWSService<T>(lifetime);
+        }
+    }
+}

--- a/src/Peekaqueue/Program.cs
+++ b/src/Peekaqueue/Program.cs
@@ -33,7 +33,7 @@ namespace Peekaqueue
             services.AddMediatR();
             services.AddSingleton(Log.Logger);
             services.AddDefaultAWSOptions(context.Configuration.GetAWSOptions());
-            services.AddAWSService<IAmazonSQS>();
+            services.AddAWSServiceWithOverride<IAmazonSQS>(context.Configuration, "AWS:Sqs");
             services.AddAWSService<IAmazonECS>();
             services.AddAWSService<IAmazonCloudWatch>();
 


### PR DESCRIPTION
### Description:
While peekaqueue is a very helpful tool to monitor queues, it currently works only with an actual AWS account/profile. Adding local support (when developing against localstack or other similar services), would help developers identify potential improvements, application needs, and metrics earlier in the pipeline.

This PR brings a small change which allows the registration of AWS services with different configurations which enables to use of mock services.

### Testing.
Testing was done by wrapping this image in a container so that it is found on the same network as other services (including mocks)

sample:
```
version: "3.5"

services:

    peekaqueue:
        build:
            context: .
            dockerfile: ./src/Peekaqueue/Dockerfile
        image: peekaqueue
        container_name: peekaqueue
        environment:
            - AWS_REGION=eu-west-2
            - AWS_ACCESS_KEY_ID=XXX
            - AWS_SECRET_ACCESS_KEY=XXX
            - PEEKAQ_MONITORING__QUEUES__0__Name=net-mgt-msg
            - PEEKAQ_AWS__Sqs__ServiceURL=http://goaws:4100
        ports: 
            - 5000:5000
        networks:
            - aws-mock-network

networks:
    aws-mock-network:
        name: aws-mock-network
```